### PR TITLE
Add chat migration linking users

### DIFF
--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,3 +1,5 @@
 class Chat < ApplicationRecord
   has_many :messages
+  belongs_to :helpee, class_name: "User"
+  belongs_to :helper, class_name: "User", optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,6 @@ class User < ApplicationRecord
   end
 
   def is_helper?
-    true
+    self.is_helper
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :messages, dependent: :destroy
+  has_many :helper_chats, class_name: "Chat", foreign_key: "helper_id", dependent: :destroy
+  has_many :helpee_chats, class_name: "Chat", foreign_key: "helpee_id", dependent: :destroy
+
 
   def avatar_url
     "http://placecage.com/40/40"

--- a/db/migrate/20181121114127_add_helper_and_helpee_references_to_chats.rb
+++ b/db/migrate/20181121114127_add_helper_and_helpee_references_to_chats.rb
@@ -1,0 +1,6 @@
+class AddHelperAndHelpeeReferencesToChats < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :chats, :helpee
+    add_reference :chats, :helper
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_20_105112) do
+ActiveRecord::Schema.define(version: 2018_11_21_114127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,10 @@ ActiveRecord::Schema.define(version: 2018_11_20_105112) do
   create_table "chats", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "helpee_id"
+    t.bigint "helper_id"
+    t.index ["helpee_id"], name: "index_chats_on_helpee_id"
+    t.index ["helper_id"], name: "index_chats_on_helper_id"
   end
 
   create_table "messages", force: :cascade do |t|


### PR DESCRIPTION
Added foreign keys to chats table to identify helper and helpee for each chat. The helpee id is required, but the helper id is optional, so that the chat can be created with just the helpee and the helper can be added on later. I also changed the user is_helper? method, it always returned true when called, now it returns the is_helper boolean of the user it is called on.